### PR TITLE
Static data endpoint doesn't use the config values

### DIFF
--- a/driftbase/staticdata/handlers.py
+++ b/driftbase/staticdata/handlers.py
@@ -37,11 +37,11 @@ def get_static_data_ids():
             }
             origin = "Hardcoded defaults"
 
-            repo = data['repository']
-            revs[repo] = data, origin
+        repo = data['repository']
+        revs[repo] = data, origin
     except:
         log.error("Error getting static data. data='%s', origin='%s'" % (repr(data), origin))
-        log.exception()
+        log.exception("Failed to get static data config.")
 
     return revs
 
@@ -92,7 +92,6 @@ class StaticDataAPI(Resource):
             if err:
                 data["error"] = err
                 continue
-            print "ref_entry", ref_entry
             index_file = {ref_entry["ref"]: ref_entry for ref_entry in index_file["index"]}
 
             # Use this ref if it matches


### PR DESCRIPTION
Due to an indentation problem, tenant static data config was never returned properly, and the unit tests didn't test enough to detect this. The unit tests were also not updated to modify the config in the new location.

Please see the change list for details, and feel free to modify how the test mocks the config, as I'm not sure this is the right way.