### PR TITLE
Fixed the response from the /players endpoint

### DIFF
--- a/driftbase/api/players/__init__.py
+++ b/driftbase/api/players/__init__.py
@@ -37,8 +37,9 @@ endpoints = Endpoints()
 class PlayerSchema(ModelSchema):
     class Meta:
         strict = True
+        include_fk = True # required to expose the 'user_id' field
         model = CorePlayer
-        exclude = ('ck_player_summary',)
+        exclude = ('ck_player_summary', 'user')
 
     is_online = ma.fields.Boolean()
 


### PR DESCRIPTION
- that endpoint used to return the user id in the "user" field instead of "user_id" field, this is now fixed
- see related discussion at https://github.com/marshmallow-code/marshmallow-sqlalchemy/issues/118
- this will also fix https://github.com/dgnorth/drift-base/issues/9