### PR TITLE
Feature/gevent

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ greenlet = "*"
 python-decouple = "*"
 flask-restx = "*"
 python-driftconfig = "*"
+psycogreen = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0b98f573ca0dbf6c903c8cfc6ff7ae42d55303a682a17b8a3f6ff3ad677e4667"
+            "sha256": "e274d706267f4185547ab80d0d0bd69c60f446e0f714e05703e957b949196aa0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -375,6 +375,13 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.23.1"
         },
+        "psycogreen": {
+            "hashes": [
+                "sha256:c429845a8a49cf2f76b71265008760bcd7c7c77d80b806db4dc81116dbcd130d"
+            ],
+            "index": "pypi",
+            "version": "==1.0.2"
+        },
         "psycopg2-binary": {
             "hashes": [
                 "sha256:008da3ab51adc70a5f1cfbbe5db3a22607ab030eb44bcecf517ad11a0c2b3cac",
@@ -471,11 +478,11 @@
         },
         "python-editor": {
             "hashes": [
-                "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522",
-                "sha256:c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77",
                 "sha256:1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d",
+                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b",
                 "sha256:5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8",
-                "sha256:51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b"
+                "sha256:c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77",
+                "sha256:ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522"
             ],
             "version": "==1.0.4"
         },
@@ -514,10 +521,10 @@
                 "flask"
             ],
             "hashes": [
-                "sha256:da06bc3641e81ec2c942f87a0676cd9180044fa3d1697524a0005345997542e2",
-                "sha256:e80d61af85d99a1222c1a3e2a24023618374cd50a99673aa7fa3cf920e7d813b"
+                "sha256:2f023ff348359ec5f0b73a840e8b08e6a8d3b2613a98c57d11c222ef43879237",
+                "sha256:380a280cfc7c4ade5912294e6d9aa71ce776b5fca60a3782e9331b0bcd2866bf"
             ],
-            "version": "==0.16.0"
+            "version": "==0.16.1"
         },
         "six": {
             "hashes": [

--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -14,15 +14,13 @@ uid = uwsgi
 pidfile = /tmp/uwsgi.pid
 
 # Threading management info
-threads = 4
-#gevent = 100
-cheaper = 2
-workers = %(4 * %k)
-# max-worker-lifetime = 600
-idle = true
+enable-threads = true
+threads = without
+gevent = 1000
+workers = %(1 * %k)
 
 # Application info
-module=drift.contrib.flask.plainapp:app
+module=driftbase.flask.driftbaseapp:app
 
 # Web servers for nginx reverse proxy, local testing and uwsgitop.
 # Number of listening sockets set to a rather high number.

--- a/config/uwsgi.ini
+++ b/config/uwsgi.ini
@@ -1,15 +1,25 @@
 [uwsgi]
+# Accept only valid configuration options
+strict = true
 
 # Process management info
+master = true
+single-interpreter = true
+need-app = true
+auto-procname = true
+procname-prefix = "drift-base "
+die-on-term = true
+vacuum = true
+uid = uwsgi
+pidfile = /tmp/uwsgi.pid
+
+# Threading management info
 threads = 4
 #gevent = 100
-master = true
-uid = uwsgi
 cheaper = 2
 workers = %(4 * %k)
 # max-worker-lifetime = 600
 idle = true
-pidfile = /tmp/uwsgi.pid
 
 # Application info
 module=drift.contrib.flask.plainapp:app

--- a/driftbase/api/messages.py
+++ b/driftbase/api/messages.py
@@ -142,9 +142,6 @@ class MessagesExchangeAPI(MethodView):
 
         args = self.get_args.parse_args()
         timeout = args.timeout or 0
-        #! Set timeout to 0 to disable long polling until we can
-        #! get gevent up and running in uwsgi.
-        timeout = 0
         min_message_number = int(args.messages_after or 0) + 1
         rows = args.rows
         if rows:

--- a/driftbase/flask/driftbaseapp.py
+++ b/driftbase/flask/driftbaseapp.py
@@ -1,0 +1,13 @@
+"""
+Flask app with gevent monkey patching.
+"""
+import logging
+
+from gevent import monkey
+monkey.patch_all()
+from psycogreen.gevent import patch_psycopg
+patch_psycopg()
+
+from drift.flaskfactory import drift_app
+
+app = drift_app()


### PR DESCRIPTION
Switch gevent threading mode

- Use a custom flask factory to inject gevent monkey patching for the system and psycopg.
- Configure uWSGI to run one worker per CPU and 1000 cores per worker. This needs additional profiling, but works.
- Tidy up uWSGI config to catch broken apps, bad configurations
- Disable cheaper mode for now, until profiling has been done